### PR TITLE
EXP: replace scikit-image with ahe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,16 +8,20 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
+  "matplotlib>=3.10.1",
+  "rlic>=0.5.1",
+  "scikit-image>=0.25.2",
+  "scipy>=1.15.2",
+]
+
+[dependency-groups]
+playground = [
   "astropy>=7.1.0",
   "ipykernel>=6.30.1",
   "ipympl>=0.9.7",
   "jupyterlab>=4.4.6",
   "jupyterlab-lsp>=5.2.0",
-  "matplotlib>=3.10.1",
   "python-lsp-server>=1.13.0",
-  "rlic>=0.5.1",
-  "scikit-image>=0.25.2",
-  "scipy>=1.15.2",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
+  "ahe>=0.1.0",
   "matplotlib>=3.10.1",
   "rlic>=0.5.1",
-  "scikit-image>=0.25.2",
   "scipy>=1.15.2",
 ]
 

--- a/src/vegtamr/lic/_api.py
+++ b/src/vegtamr/lic/_api.py
@@ -191,7 +191,7 @@ def compute_lic_with_postprocessing(
             )
             sfield_in = sfield
         if use_filter: sfield = _postprocess.filter_highpass(sfield, sigma=filter_sigma)
-        if use_equalize: sfield = _postprocess.rescaled_equalize(sfield)
+        if use_equalize: sfield = _postprocess.rescaled_equalize(sfield, use_periodic_BCs=use_periodic_BCs)
         return sfield
     elif backend.lower() == "rust":
         if verbose:
@@ -215,7 +215,7 @@ def compute_lic_with_postprocessing(
         sfield /= numpy.max(numpy.abs(sfield))
         sfield_in = sfield
         if use_filter: sfield = _postprocess.filter_highpass(sfield, sigma=filter_sigma)
-        if use_equalize: sfield = _postprocess.rescaled_equalize(sfield)
+        if use_equalize: sfield = _postprocess.rescaled_equalize(sfield, use_periodic_BCs=use_periodic_BCs)
         return sfield
     else:
         raise ValueError(f"Unsupported backend: `{backend}`.")

--- a/src/vegtamr/utils/_postprocess.py
+++ b/src/vegtamr/utils/_postprocess.py
@@ -9,8 +9,8 @@
 ##
 
 import numpy
+from ahe import equalize_histogram
 from scipy import ndimage
-from skimage.exposure import equalize_adapthist
 
 ##
 ## === FUNCTIONS ===
@@ -32,16 +32,22 @@ def rescaled_equalize(
     num_subregions_cols: int = 8,
     clip_intensity_gradient: float = 0.01,
     num_intensity_bins: int = 150,
+    *,
+    use_periodic_BCs: bool
 ) -> numpy.ndarray:
     min_val = sfield.min()
     max_val = sfield.max()
     is_rescale_needed = (max_val > 1.0) or (min_val < 0.0)
     ## rescale values to enhance local contrast
     ## note, output values are bound by [0, 1]
-    sfield = equalize_adapthist(
-        image=sfield,
-        kernel_size=(num_subregions_rows, num_subregions_cols),
-        clip_limit=clip_intensity_gradient,
+    sfield = equalize_histogram(
+        sfield,
+        adaptive_strategy={
+            "kind": "tile-interpolation",
+            "tile-into": (num_subregions_rows, num_subregions_cols),
+        },
+        boundaries="periodic" if use_periodic_BCs else "reflect",
+        max_normalized_bincount=clip_intensity_gradient,
         nbins=num_intensity_bins,
     )
     ## rescale field back to its original value range

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,24 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "ahe"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/8b/4907f351ef14acef86dc2a62da70904dc50ffba05469276bf06375dff35c/ahe-0.1.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6e2bf7b597d04c540c686f7acdf2bc2645d75ecc95f484f93a5ed75c5d1cd7dc", size = 233182, upload-time = "2026-01-27T15:46:42.133Z" },
+    { url = "https://files.pythonhosted.org/packages/72/97/7f79539786f571b01f29e080eec71fc9730e8f112deac666b0045880fb51/ahe-0.1.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:6a016593b55fa9da72edccb9ace4ab606c004addd999ee575d35d44dbf875fb0", size = 221794, upload-time = "2026-01-27T15:46:43.975Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/23/c54c7956fc63c83a65a91e3ee89596a8a09e8941007d7094d98a8fcbdb3d/ahe-0.1.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f73a6082cdc3ff6d512eef9aa26e0577c9dbb95a4461506bd27d06e66df791b1", size = 242320, upload-time = "2026-01-27T15:46:46.911Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/bb/f495887b826e98ea78fae8cddb8373862d5240359e645f0330da40b8a2fa/ahe-0.1.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7765e88d686121ac77662974582bde1417934d0c47fc4f8f94e8b9c40302ffc7", size = 255046, upload-time = "2026-01-27T15:46:48.386Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/dd/2c7037cd635149956b8754040bb035efc662454b9b7e0d5c1969bcd58b3e/ahe-0.1.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:122a4bb222064773ec2feb4ffd886c307d3ea48fc0f7890fed8f93171f4457be", size = 425434, upload-time = "2026-01-27T15:46:50.019Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/40/92e3e462548deb1e167f6e4f57cfb9d2be9554bb48853a4fef917205d2f2/ahe-0.1.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4fab4ea9a195abe9efdf2af8905dca72293d6aecb5b60b6bc73dc5df4f11ca84", size = 467587, upload-time = "2026-01-27T15:46:51.878Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/bd/e6cad012e5dfa3a283778572ca99c2c1533cd7b1071e2b78e705a076765a/ahe-0.1.0-cp310-abi3-win32.whl", hash = "sha256:3773381c0b043294df045d16c7ed0c53c57c468d2fd69a43c3991e3ba00a3080", size = 144494, upload-time = "2026-01-27T15:46:53.262Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/f5/19515a1188c7512576abafe3a4b30ba7b7aa67a8f8b2cfb508bf5ff35ec7/ahe-0.1.0-cp310-abi3-win_amd64.whl", hash = "sha256:d3edea04d8348db14e7dff505f289ae7a9504fd88291561b0e6923e0d140ac24", size = 152169, upload-time = "2026-01-27T15:46:54.66Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -608,19 +626,6 @@ wheels = [
 ]
 
 [[package]]
-name = "imageio"
-version = "2.37.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/47/57e897fb7094afb2d26e8b2e4af9a45c7cf1a405acdeeca001fdf2c98501/imageio-2.37.0.tar.gz", hash = "sha256:71b57b3669666272c818497aebba2b4c5f20d5b37c81720e5e1a56d59c492996", size = 389963, upload-time = "2025-01-20T02:42:37.089Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/bd/b394387b598ed84d8d0fa90611a90bee0adc2021820ad5729f7ced74a8e2/imageio-2.37.0-py3-none-any.whl", hash = "sha256:11efa15b87bc7871b61590326b2d635439acc321cf7f8ce996f812543ce10eed", size = 315796, upload-time = "2025-01-20T02:42:34.931Z" },
-]
-
-[[package]]
 name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1070,18 +1075,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lazy-loader"
-version = "0.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6b/c875b30a1ba490860c93da4cabf479e03f584eba06fe5963f6f6644653d8/lazy_loader-0.4.tar.gz", hash = "sha256:47c75182589b91a4e1a85a136c074285a5ad4d9f39c63e0d7fb76391c4574cd1", size = 15431, upload-time = "2024-04-05T13:03:12.261Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/60/d497a310bde3f01cb805196ac61b7ad6dc5dcf8dce66634dc34364b20b4f/lazy_loader-0.4-py3-none-any.whl", hash = "sha256:342aa8e14d543a154047afb4ba8ef17f5563baad3fc610d7b15b213b0f119efc", size = 12097, upload-time = "2024-04-05T13:03:10.514Z" },
-]
-
-[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1264,15 +1257,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
-]
-
-[[package]]
-name = "networkx"
-version = "3.4.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
 ]
 
 [[package]]
@@ -1932,40 +1916,6 @@ wheels = [
 ]
 
 [[package]]
-name = "scikit-image"
-version = "0.25.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "imageio" },
-    { name = "lazy-loader" },
-    { name = "networkx" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "scipy" },
-    { name = "tifffile" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/a8/3c0f256012b93dd2cb6fda9245e9f4bff7dc0486880b248005f15ea2255e/scikit_image-0.25.2.tar.gz", hash = "sha256:e5a37e6cd4d0c018a7a55b9d601357e3382826d3888c10d0213fc63bff977dde", size = 22693594, upload-time = "2025-02-18T18:05:24.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/97/3051c68b782ee3f1fb7f8f5bb7d535cf8cb92e8aae18fa9c1cdf7e15150d/scikit_image-0.25.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f4bac9196fb80d37567316581c6060763b0f4893d3aca34a9ede3825bc035b17", size = 14003057, upload-time = "2025-02-18T18:04:30.395Z" },
-    { url = "https://files.pythonhosted.org/packages/19/23/257fc696c562639826065514d551b7b9b969520bd902c3a8e2fcff5b9e17/scikit_image-0.25.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:d989d64ff92e0c6c0f2018c7495a5b20e2451839299a018e0e5108b2680f71e0", size = 13180335, upload-time = "2025-02-18T18:04:33.449Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/14/0c4a02cb27ca8b1e836886b9ec7c9149de03053650e9e2ed0625f248dd92/scikit_image-0.25.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2cfc96b27afe9a05bc92f8c6235321d3a66499995675b27415e0d0c76625173", size = 14144783, upload-time = "2025-02-18T18:04:36.594Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/9b/9fb556463a34d9842491d72a421942c8baff4281025859c84fcdb5e7e602/scikit_image-0.25.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24cc986e1f4187a12aa319f777b36008764e856e5013666a4a83f8df083c2641", size = 14785376, upload-time = "2025-02-18T18:04:39.856Z" },
-    { url = "https://files.pythonhosted.org/packages/de/ec/b57c500ee85885df5f2188f8bb70398481393a69de44a00d6f1d055f103c/scikit_image-0.25.2-cp311-cp311-win_amd64.whl", hash = "sha256:b4f6b61fc2db6340696afe3db6b26e0356911529f5f6aee8c322aa5157490c9b", size = 12791698, upload-time = "2025-02-18T18:04:42.868Z" },
-    { url = "https://files.pythonhosted.org/packages/35/8c/5df82881284459f6eec796a5ac2a0a304bb3384eec2e73f35cfdfcfbf20c/scikit_image-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8db8dd03663112783221bf01ccfc9512d1cc50ac9b5b0fe8f4023967564719fb", size = 13986000, upload-time = "2025-02-18T18:04:47.156Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/e6/93bebe1abcdce9513ffec01d8af02528b4c41fb3c1e46336d70b9ed4ef0d/scikit_image-0.25.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:483bd8cc10c3d8a7a37fae36dfa5b21e239bd4ee121d91cad1f81bba10cfb0ed", size = 13235893, upload-time = "2025-02-18T18:04:51.049Z" },
-    { url = "https://files.pythonhosted.org/packages/53/4b/eda616e33f67129e5979a9eb33c710013caa3aa8a921991e6cc0b22cea33/scikit_image-0.25.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d1e80107bcf2bf1291acfc0bf0425dceb8890abe9f38d8e94e23497cbf7ee0d", size = 14178389, upload-time = "2025-02-18T18:04:54.245Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/b5/b75527c0f9532dd8a93e8e7cd8e62e547b9f207d4c11e24f0006e8646b36/scikit_image-0.25.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a17e17eb8562660cc0d31bb55643a4da996a81944b82c54805c91b3fe66f4824", size = 15003435, upload-time = "2025-02-18T18:04:57.586Z" },
-    { url = "https://files.pythonhosted.org/packages/34/e3/49beb08ebccda3c21e871b607c1cb2f258c3fa0d2f609fed0a5ba741b92d/scikit_image-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:bdd2b8c1de0849964dbc54037f36b4e9420157e67e45a8709a80d727f52c7da2", size = 12899474, upload-time = "2025-02-18T18:05:01.166Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/7c/9814dd1c637f7a0e44342985a76f95a55dd04be60154247679fd96c7169f/scikit_image-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7efa888130f6c548ec0439b1a7ed7295bc10105458a421e9bf739b457730b6da", size = 13921841, upload-time = "2025-02-18T18:05:03.963Z" },
-    { url = "https://files.pythonhosted.org/packages/84/06/66a2e7661d6f526740c309e9717d3bd07b473661d5cdddef4dd978edab25/scikit_image-0.25.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:dd8011efe69c3641920614d550f5505f83658fe33581e49bed86feab43a180fc", size = 13196862, upload-time = "2025-02-18T18:05:06.986Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/63/3368902ed79305f74c2ca8c297dfeb4307269cbe6402412668e322837143/scikit_image-0.25.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28182a9d3e2ce3c2e251383bdda68f8d88d9fff1a3ebe1eb61206595c9773341", size = 14117785, upload-time = "2025-02-18T18:05:10.69Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/9b/c3da56a145f52cd61a68b8465d6a29d9503bc45bc993bb45e84371c97d94/scikit_image-0.25.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8abd3c805ce6944b941cfed0406d88faeb19bab3ed3d4b50187af55cf24d147", size = 14977119, upload-time = "2025-02-18T18:05:13.871Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/97/5fcf332e1753831abb99a2525180d3fb0d70918d461ebda9873f66dcc12f/scikit_image-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:64785a8acefee460ec49a354706db0b09d1f325674107d7fa3eadb663fb56d6f", size = 12885116, upload-time = "2025-02-18T18:05:17.844Z" },
-    { url = "https://files.pythonhosted.org/packages/10/cc/75e9f17e3670b5ed93c32456fda823333c6279b144cd93e2c03aa06aa472/scikit_image-0.25.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:330d061bd107d12f8d68f1d611ae27b3b813b8cdb0300a71d07b1379178dd4cd", size = 13862801, upload-time = "2025-02-18T18:05:20.783Z" },
-]
-
-[[package]]
 name = "scipy"
 version = "1.15.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2083,18 +2033,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
-]
-
-[[package]]
-name = "tifffile"
-version = "2025.3.30"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/54/d5ebe66a9de349b833e570e87bdbd9eec76ec54bd505c24b0591a15783ad/tifffile-2025.3.30.tar.gz", hash = "sha256:3cdee47fe06cd75367c16bc3ff34523713156dae6cd498e3a392e5b39a51b789", size = 366039, upload-time = "2025-03-30T04:45:30.503Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/be/10d23cfd4078fbec6aba768a357eff9e70c0b6d2a07398425985c524ad2a/tifffile-2025.3.30-py3-none-any.whl", hash = "sha256:0ed6eee7b66771db2d1bfc42262a51b01887505d35539daef118f4ff8c0f629c", size = 226837, upload-time = "2025-03-30T04:45:29Z" },
 ]
 
 [[package]]
@@ -2247,9 +2185,9 @@ name = "vegtamr"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "ahe" },
     { name = "matplotlib" },
     { name = "rlic" },
-    { name = "scikit-image" },
     { name = "scipy" },
 ]
 
@@ -2265,9 +2203,9 @@ playground = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ahe", specifier = ">=0.1.0" },
     { name = "matplotlib", specifier = ">=3.10.1" },
     { name = "rlic", specifier = ">=0.5.1" },
-    { name = "scikit-image", specifier = ">=0.25.2" },
     { name = "scipy", specifier = ">=1.15.2" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -2247,30 +2247,38 @@ name = "vegtamr"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "astropy" },
-    { name = "ipykernel" },
-    { name = "ipympl" },
-    { name = "jupyterlab" },
-    { name = "jupyterlab-lsp" },
     { name = "matplotlib" },
-    { name = "python-lsp-server" },
     { name = "rlic" },
     { name = "scikit-image" },
     { name = "scipy" },
 ]
 
+[package.dev-dependencies]
+playground = [
+    { name = "astropy" },
+    { name = "ipykernel" },
+    { name = "ipympl" },
+    { name = "jupyterlab" },
+    { name = "jupyterlab-lsp" },
+    { name = "python-lsp-server" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "matplotlib", specifier = ">=3.10.1" },
+    { name = "rlic", specifier = ">=0.5.1" },
+    { name = "scikit-image", specifier = ">=0.25.2" },
+    { name = "scipy", specifier = ">=1.15.2" },
+]
+
+[package.metadata.requires-dev]
+playground = [
     { name = "astropy", specifier = ">=7.1.0" },
     { name = "ipykernel", specifier = ">=6.30.1" },
     { name = "ipympl", specifier = ">=0.9.7" },
     { name = "jupyterlab", specifier = ">=4.4.6" },
     { name = "jupyterlab-lsp", specifier = ">=5.2.0" },
-    { name = "matplotlib", specifier = ">=3.10.1" },
     { name = "python-lsp-server", specifier = ">=1.13.0" },
-    { name = "rlic", specifier = ">=0.5.1" },
-    { name = "scikit-image", specifier = ">=0.25.2" },
-    { name = "scipy", specifier = ">=1.15.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is an experiment/proof-of-concept that would close #11
It uses a dev branch at https://github.com/neutrinoceros/ahe/pull/63 and is based on top of #13.
I think the results look promising but they are also strikingly different than references, and I don't understand why yet.


main
<img width="1168" height="1168" alt="lic_swirls" src="https://github.com/user-attachments/assets/f0b8b978-e7b5-4da1-bf6a-e0c291d2a502" />


this branch
<img width="1168" height="1168" alt="lic_swirls" src="https://github.com/user-attachments/assets/a9dbd2d3-20fd-426e-8f14-667e55919756" />
